### PR TITLE
Comm. of Advent Feria on 12/2

### DIFF
--- a/hymns/iste_confessor.gabc
+++ b/hymns/iste_confessor.gabc
@@ -3,7 +3,7 @@ office-part:Hymnus;
 mode:1;
 transcriber:Dominique CROCHU;
 %%
-(c4)I(d!ewfd)te(dc) Con(cd)fés(d.)sor(d.) (,) Dó(f)mi(e)ni(d') sa(e)crá(e.)tus,(d.) (;)
+(c4) IS(d!ewfd)te(dc) Con(cd)fés(d.)sor(d.) (,) Dó(f)mi(e)ni(d') sa(e)crá(e.)tus,(d.) (;)
 Fes(dh'!iv)ta(h') plebs(h) cu(hg)ius(g_h) ce(f)le(gh)brat(g) per(fg) or(gvFE)bem,(d.) (:)
 Hac(dg) di(fe)e(dc) læ(dd)tus(c.) (,) mé(fe)ru(fg)it(fe) su(dc)pré(de)mos(e_d) (,)
 Lau(d!ewfd)dis(dc) ho(cd)nó(d.)res.(d.) (::)

--- a/inserts/12-02-2022/12-02-2022.tex
+++ b/inserts/12-02-2022/12-02-2022.tex
@@ -130,7 +130,6 @@
 
 \end{latinenglishsection}
 
-\vfill\pagebreak
 
 \textit{\color{red}For commemorations, the Cantor intones the antiphon and says the responsorial prayer afterwards. The Officiant prays the associated collect.}
 
@@ -141,6 +140,8 @@
 \gresetinitiallines{1}
 \gregorioscore{../../commemorations/virgin-2v}
 % PT: \gregorioscore{../commemorations/virgin-2v-pt}
+
+\vfill\pagebreak
 
 \begin{latinenglishsection}
 
@@ -163,7 +164,36 @@
 
 \end{latinenglishsection}
 
+\section*{Commemoration of the Feria in Advent}
+
+\textit{\textnormal{Ant.} Out of Egypt I have called my Son: he will come to save his people.}
+
+\gresetinitiallines{1}
+\gregorioscore{comm-advent}
+
 \textit{\color{red}The Officiant leads the following:}
+
+\begin{latinenglishsection}
+
+\latinenglish{
+	{\color{red}\Vbar.}~Roráte cæli désuper, et nubes pluant justum.\\
+	{\color{red}\Rbar.}~Aperiátur terra, et gérminet Salvatórem.
+	
+	Orémus.
+	Excita, qu\'{\ae}sumus, Dómine, poténtiam tuam, et veni:~\GreDagger\
+	ut ab imminéntibus peccatórum nostrórum perículis, te mereámur pro\textbf{te}\textit{génte} \textbf{é}ripi, te liberánte salvári.~*
+	Qui vivis et regnas in unitáte Spíritus Sancti, Deus, per ómnia s\'{\ae}cula sæculórum.\\
+	{\color{red}\Rbar.}~Amen.
+}{
+	Drop down dew, ye heavens, from above, and let the clouds rain the Just One.
+	{\color{red}\Rbar.}~Let the earth be opened, and bud forth the Savior.
+	
+	Let us pray.
+	Show forth Thy power, O Lord, we beseech Thee, and come, that with Thee as our protector we may be rescued from the impending danger of our sins; and with Thee as our deliverer, we may obtain our salvation.
+	{\color{red}\Rbar.}~Amen.
+}
+
+\end{latinenglishsection}
 
 \begin{latinenglishsection}
 

--- a/inserts/12-02-2022/comm-advent.gabc
+++ b/inserts/12-02-2022/comm-advent.gabc
@@ -1,0 +1,7 @@
+name:Ex Aegypto vocavi;
+office-part:Antiphona;
+mode:4;
+book:Liber antiphonarius, 1960, p. 222;
+transcriber:Andrew Hinkley;
+%%
+(c3) EX(f') Æ(h)gýp(hi)to(i'_) *(,) vo(i)cá(i')vi(h) Fí(ij)li(h)um(ij) me(i_)um:(i.) (;) vé(f')ni(i)et(g') ut(h) sal(f_e~)vet(f_e) (,) pó(d_e)pu(f')lum(h) su(f.)um.(f.) (::)


### PR DESCRIPTION
The antiphon "Ex Aegypto" is that given for the Friday in the first week of Advent. The V/R/ "Rorate caeli" is used at Vespers throughout Advent, and the prayer "Excita quaesumus" comes from the preceding Sunday.